### PR TITLE
Fix scansat contracts to require tech instead of part

### DIFF
--- a/GameData/LRTR/contracts/ScanSat/Earth_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/Earth_AltimetryLoRes.cfg
@@ -60,10 +60,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/Mars_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/Mars_AltimetryLoRes.cfg
@@ -61,10 +61,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/Moon_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/Moon_AltimetryLoRes.cfg
@@ -61,10 +61,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_AltimetryLoRes.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for MS-1 Multispectral Scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner2
-		title = Have unlocked the High Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = spaceExploration
+		title = Have unlocked Lunar Exploration Era Science for SAR-C Antenna
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -12,7 +12,7 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of Earth. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of Earth.
+	synopsis = Perform @/scanReadString1 survey of Earth.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the planet.
 
@@ -43,14 +43,14 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	DATA_EXPAND
 	{
 		type			= string
-		scanString1		= [ "AltimetryLoRes", "Biome", "AltimetryHiRes" ]	
+		scanString1		= [ "Biome", "AltimetryHiRes" ]	
 	}
 	
 	DATA
 	{
 		type			= string
 		uniquenessCheck	= CONTRACT_ALL
-		scanReadString1	= @/scanString1	== "AltimetryLoRes" ? "a Low Resolution" : @/scanString1 == "Biome" ? "a Biome" : "a High Resolution"
+		scanReadString1	= @/scanString1	== "Biome" ? "a Biome" : "a High Resolution"
 	}
 	
 	// ************ REQUIREMENTS ************
@@ -75,10 +75,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "Biome" ? "basicScience" : "spaceExploration"
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
@@ -96,10 +96,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for MS-1 Multispectral Scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_AltimetryLoRes.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner
-		title = Have unlocked the Low Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for MS-1 Multispectral Scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
@@ -95,10 +95,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner2
-		title = Have unlocked the High Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = spaceExploration
+		title = Have unlocked Lunar Exploration Era Science for SAR-C Antenna
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
@@ -5,14 +5,14 @@
 CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 {
 	name = LRTR_SCANSat_JupiterMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Jupiter
 	group = LRTRScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? "basicScience" : @/scanString1 == "Biome" ? "basicScience" : "spaceExploration"
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
@@ -5,14 +5,14 @@
 CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 {
 	name = LRTR_SCANSat_NeptuneMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Neptune
 	group = LRTRScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? "basicScience" : @/scanString1 == "Biome" ? "basicScience" : "spaceExploration"
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
@@ -5,14 +5,14 @@
 CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 {
 	name = LRTR_SCANSat_SaturnMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Saturn
 	group = LRTRScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? "basicScience" : @/scanString1 == "Biome" ? "basicScience" : "spaceExploration"
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
+++ b/GameData/LRTR/contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
@@ -5,14 +5,14 @@
 CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 {
 	name = LRTR_SCANSat_UranusMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Uranus
 	group = LRTRScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? "basicScience" : @/scanString1 == "Biome" ? "basicScience" : "spaceExploration"
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/LRTR/contracts/ScanSat/Venus_AltimetryLoRes.cfg
+++ b/GameData/LRTR/contracts/ScanSat/Venus_AltimetryLoRes.cfg
@@ -61,10 +61,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************
@@ -142,10 +142,10 @@ CONTRACT_TYPE:NEEDS[LRTRContracts,SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = basicScience
+		title = Have unlocked Early Human Spaceflight Era Science for R-3B Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Adds parity with PR https://github.com/KSP-RO/RP-0/pull/1574 on RP-0

Scansat contracts currently require an obselete part to be unlocked, so they never trigger.  This updates all scansat contracts to require the technology that unlocks the first Scansat module of the required type.